### PR TITLE
Implementerer alle forovertrekk (hvit bonde) i oppgave 1

### DIFF
--- a/src/task_1/hint.md
+++ b/src/task_1/hint.md
@@ -50,11 +50,14 @@ match y {
 <details>
 <summary>Hint 4 – Åpningstrekk for hvit bonde</summary>
 
-Her følger en enkel kode for å finne bondens vanlige trekk (for å gå fremover, ikke for å slå andre brikker):
+Denne koden gir det åpningstrekkene for en hvit bonde (som gjelder når `y = 1`):
 
 ```rust
-let (x, _) = self.position;
-HashSet::from([(x, 2), (x, 3)])
+let (x, y) = self.position;
+match y {
+    1 => HashSet::from([(x, 2), (x, 3)]),
+    ...
+}
 ```
 
 </details>
@@ -62,11 +65,16 @@ HashSet::from([(x, 2), (x, 3)])
 <details>
 <summary>Hint 5 – Generell bevegelse for hvit bonde</summary>
 
-Her følger en enkel kode for å finne bondens vanlige trekk (for å gå fremover, ikke for å slå andre brikker):
+Her følger en enkel kode for å finne bondens andre forovertrekk (når bonden ikke er i åpningspersjon, altså `y > 1`):
 
 ```rust
 let (x, y) = self.position;
-HashSet::from([(x, y + 1)])
+match y {
+    1 => // logikk for y = 1,
+    _ => HashSet::from([(x, y + 1)]),
+...
+}
+
 ```
 
 </details>

--- a/src/task_1/hint.md
+++ b/src/task_1/hint.md
@@ -7,7 +7,7 @@
 
 Hvit bonde er i åpningsposisjon når `y = 1`. Hva er da `y`-verdien til de to gyldige åpningstrekkene?
 
-Dersom bonden ikke er i åpningsposisjonen, vet du at bonden kan flytte til feltet rett over (med mindre bonden står ved øverste rad av brettet).
+Dersom `y != 1`, vet du at bonden ikke er i åpningsposisjonen. Da kan den flytte til feltet rett over.
 
 </details>
 
@@ -30,10 +30,25 @@ let filled_hash_set = HashSet::from([(0, 0), (0, 1)])
 
 </details>
 
+<details>
+<summary>Hint 3 – match</summary>
+
+Bruk `match` for å skrive ulik logikk for ulike verdier av bondens `y`-verdi:
+
+```rust
+let (x, y) = self.position;
+match y {
+    1 => // logikk for y = 1,
+    _ => // logikk for y != 1
+}
+```
+
+</details>
+
 ## Hint som avslører en mulig løsning
 
 <details>
-<summary>Hint 3 – Åpningstrekk for hvit bonde</summary>
+<summary>Hint 4 – Åpningstrekk for hvit bonde</summary>
 
 Her følger en enkel kode for å finne bondens vanlige trekk (for å gå fremover, ikke for å slå andre brikker):
 
@@ -45,7 +60,7 @@ HashSet::from([(x, 2), (x, 3)])
 </details>
 
 <details>
-<summary>Hint 4 – Generell bevegelse for hvit bonde</summary>
+<summary>Hint 5 – Generell bevegelse for hvit bonde</summary>
 
 Her følger en enkel kode for å finne bondens vanlige trekk (for å gå fremover, ikke for å slå andre brikker):
 
@@ -57,7 +72,7 @@ HashSet::from([(x, y + 1)])
 </details>
 
 <details>
-<summary>Hint 5 – Løsningsforslag</summary>
+<summary>Hint 6 – Løsningsforslag</summary>
 
 ```rust
 let (x, y) = self.position;

--- a/src/task_1/hint.md
+++ b/src/task_1/hint.md
@@ -3,9 +3,11 @@
 ## Hint som er nyttige
 
 <details>
-<summary>Hint 1 – Anta at bonden er i åpningsposisjon</summary>
+<summary>Hint 1 – Når er bonden i åpningsposisjonen?</summary>
 
 Hvit bonde er i åpningsposisjon når `y = 1`. Hva er da `y`-verdien til de to gyldige åpningstrekkene?
+
+Dersom bonden ikke er i åpningsposisjonen, vet du at bonden kan flytte til feltet rett over (med mindre bonden står ved øverste rad av brettet).
 
 </details>
 
@@ -38,6 +40,32 @@ Her følger en enkel kode for å finne bondens vanlige trekk (for å gå fremove
 ```rust
 let (x, _) = self.position;
 HashSet::from([(x, 2), (x, 3)])
+```
+
+</details>
+
+<details>
+<summary>Hint 4 – Generell bevegelse for hvit bonde</summary>
+
+Her følger en enkel kode for å finne bondens vanlige trekk (for å gå fremover, ikke for å slå andre brikker):
+
+```rust
+let (x, y) = self.position;
+HashSet::from([(x, y + 1)])
+```
+
+</details>
+
+<details>
+<summary>Hint 5 – Løsningsforslag</summary>
+
+```rust
+let (x, y) = self.position;
+match y {
+    1 => HashSet::from([(x, y + 1), (x, y + 2)]),
+    7 => HashSet::new(),
+    _ => HashSet::from([(x, y + 1)]
+}
 ```
 
 </details>

--- a/src/task_1/oppgave.md
+++ b/src/task_1/oppgave.md
@@ -1,15 +1,14 @@
 # Oppgave 1
-> **Mål:** Implementere åpningstrekk for _hvit bonde_
+> **Mål:** Implementere forovertrekk for _hvit bonde_
 
 > **Hvor skal jeg jobbe:** [piece/pawn.rs](piece/pawn.rs)
 
-I denne oppgaven skal vi implementere de aller enkleste trekkene til bonden, og vi begrenser oss til kun den _hvite_ 
+I denne oppgaven skal vi implementere de første trekkene til bonden, og vi begrenser oss til kun den _hvite_ 
 bonden. I denne filen finner du en forklaring på hvordan bonden kan bevege seg, og en oppgavebeskrivelse. I koden 
 vil det finnes kommentarer som beskriver hva ulike metoder gjør, og det står `todo!()` i metoden du skal implementere.
 
 > **Obs! Les oppgaveteksten**  
-> Ikke gap over for mye! Du skal ikke implementere alle bondetrekkene på en gang, men starte med det enkleste. Vi 
-> skal implementere resten av trekkene i senere oppgaver.
+> Ikke gap over for mye! Du skal ikke implementere alle bondetrekkene på en gang, men starte med trekkene bonden kan gjøre forover, uten å tenke på om det står brikker i veien. Vi skal implementere resten av trekkene i senere oppgaver.
 
 Du finner også hint i [hint.md](./hint.md).
 
@@ -25,16 +24,15 @@ Bonden kan altså ikke gå til siden eller bakover, og den kan kun slå diagonal
 
 ![Bondetrekk](../../images/moves/pawn.gif)
 
-> **Merk!** I denne oppgaven skal vi kun implementere åpningstrekk for den hvite bonden.
+> **Merk!** I denne oppgaven skal vi kun implementere forovertrekkene for den hvite bonden.
 
 ## Oppgavebeskrivelse
 
-I denne oppgaven jobber vi videre med `Pawn`, og skal implementere åpningstrekk for den hvite bonden. Du trenger 
+I denne oppgaven jobber vi videre med `Pawn`, og skal implementere forovertrekkene for den hvite bonden. Du trenger 
 altså ikke tenke på:
-- svarte bønder,
-- hvilke trekk bonden kan gjøre etter åpningstrekket,
-- angrepstrekk,
-- eller om andre brikker kan stå i veien (dette tar vi senere)
+- om det står andre brikker i veien,
+- om bonden kan slå andre brikker,
+- eller hvordan svarte brikker kan bevege seg.
 
 Du løser oppgaven ved å implementere metodene som står definert inni `impl Pawn`- og `impl Piece for Pawn {}`-blokkene. (Se etter
 `todo!()`) `Piece` er et slags *interface*, som kalles `trait` i Rust.

--- a/src/task_1/piece/pawn.rs
+++ b/src/task_1/piece/pawn.rs
@@ -14,13 +14,13 @@ impl Pawn {
     /// Returnerer et HashSet med alle trekkene en bonde kan gjøre forover, avhengig av hvor
     /// brikken står på brettet.
     ///
-    /// I denne oppgaven (1) trenger du kun å finne åpningstrekkene for hvit bonde, og du kan anta
-    /// at det ikke står andre brikker i veien
+    /// I denne oppgaven (1) trenger du kun å finne trekkene til en hvit bonde, og du kan anta at
+    /// det ikke står noen andre brikker i veien for bonden.
     fn get_forward_moves(&self) -> HashSet<(u8, u8)> {
-        todo!("Returner et HashSet med gyldige åpningstrekk for bonden")
+        todo!("Returner et HashSet med gyldige forovertrekk for bonden")
     }
 
-    /// Returnerer trekken bonden kan gjøre for å angripe på skrå forover. Vi skal se på denne i 
+    /// Returnerer trekken bonden kan gjøre for å angripe på skrå forover. Vi skal se på denne i
     /// oppgave 3.
     fn get_capture_moves(&self) -> HashSet<(u8, u8)> {
         // Denne skal vi se på i oppgave 3
@@ -62,7 +62,6 @@ impl Piece for Pawn {
     ///
     /// # Argumenter
     /// Du trenger ikke å tenke på argumentene til denne oppgaven
-    ///
     fn get_moves(&self, _: &HashSet<(u8, u8)>, _: &HashSet<(u8, u8)>) -> HashSet<(u8, u8)> {
         let forward_moves = self.get_forward_moves();
         let capture_moves = self.get_capture_moves();
@@ -101,6 +100,13 @@ mod tests {
         let mut pawn = Pawn::new(Color::White, "d2".as_u8().unwrap());
         pawn.move_piece("d3".as_u8().unwrap());
         assert_eq!(pawn.position, "d3".as_u8().unwrap())
+    }
+
+    #[test]
+    fn one_move_for_e3_white_pawn() {
+        let pawn = Pawn::new(Color::White, "e3".as_u8().unwrap());
+        let legal_moves = set!["e4"];
+        assert_eq_set!(legal_moves, pawn.get_moves(&HashSet::from([pawn.position]), &empty_set!()))
     }
 
     #[test]

--- a/src/task_2/hint.md
+++ b/src/task_2/hint.md
@@ -3,18 +3,7 @@
 ## Hint som er nyttige
 
 <details>
-<summary>Hint 1 – Når er bonden i åpningsposisjon?</summary>
-
-Ettersom bonden kun kan gå fremover og aldri bakover, så kan du være sikker på at
-
-* Hvit bonde er i åpningsposisjon når `y = 1`
-
-Kan du bruke dette for å avgjøre når bonden skal kunne gå to felt fremover, versus når den kun får gå ett felt?
-
-</details>
-
-<details>
-<summary>Hint 2 – Hva med når en bonde står i veien?</summary>
+<summary>Hint 1 – Hva med når en brikke står i veien?</summary>
 
 - Hvilke åpningstrekk kan en bonde gjøre når det står en brikke to felt frem?
 - Hvilke åpningstrekk er tilgjengelige når det står en brikke direkte foran bonden?
@@ -25,7 +14,7 @@ Dette er tilfeller du burde ta hensyn til i koden.
 </details>
 
 <details>
-<summary>Hint 3 – Les om match</summary>
+<summary>Hint 2 – Les om match</summary>
 
 Disse tre delene av workshop-teorien kan være spesielt nyttig i denne oppgaven:
 
@@ -36,9 +25,9 @@ Disse tre delene av workshop-teorien kan være spesielt nyttig i denne oppgaven:
 </details>
 
 <details>
-<summary>Hint 4 – Les mer om HashSet</summary>
+<summary>Hint 3 – Les mer om HashSet</summary>
 
-Ta en titt på [HashSet](../../doc/teori/7-hashset-og-hashmap.md) i workshop-teorien. Spesielt operasjonene
+Ta en titt på [HashSet](../../doc/teori/7-hashset-og-hashmap.md) i workshop-teorien. Spesielt operasjonene 
 `HashSet::contains()` og `HashSet::union()` kan være nyttige for denne oppgaven.
 
 Du kan også lese mer om `HashSet` og disse metodene i
@@ -49,12 +38,37 @@ Du kan også lese mer om `HashSet` og disse metodene i
 ## Hint som avslører en mulig løsning
 
 <details>
+<summary>Hint 4 – Send inn et HashSet med andre brikkers posisjoner</summary>
+
+I `get_moves` har vi allerede `team: &HashSet<(u8, u8)>` og `rival_team: &HashSet<(u8, u8)>`, altså posisjonene til våre egne og motstanderens brikker. Hvis vi ser et par linjer lengre ned, kan vi se at to `HashSet` blir slått sammen på denne måten:
+
+```rust
+forward_moves.union(&capture_moves).cloned().collect()
+```
+
+Dette kan vi også gjøre med `team` og `rival_team` slik at vi får ett `HashSet` vi kan sende som argument til `get_forward_moves`:
+
+```rust
+let other_pieces: HashSet<_> = team.union(rival_team).cloned().collect();
+
+let forward_moves = self.get_forward_moves(&other_pieces);
+```
+
+Da må vi også oppdatere funksjonssignaturen til  `get_forward_moves` slik at den tar inn `other_pieces`:
+
+```rust
+fn get_forward_moves(&self, other_pieces: &HashSet<(u8, u8)>) -> HashSet<(u8, u8)>
+```
+
+</details>
+
+<details>
 <summary>Hint 5 – En algoritme for bondetrekk</summary>
 
 Bonden blir hindret fra å gå fremover hvis det står en annen brikke direkte foran, uansett hvordan farge den brikken
 har. Vi kan bruke dette og `match` til å lage en enkel algoritme for å finne gyldige trekk.
 
-Her følger en enkel kode for å finne bondens forovertrekk (åpningstrekk og generell bevegelse):
+Her følger en enkel kode for å finne bondens forovertrekk, med hensyn til hvor andre brikker står.
 
 ```rust
 let (x, y) = self.position;
@@ -63,7 +77,7 @@ match y {
     _ if other_pieces.contains(&(x, y + 1)) => HashSet::new(),
     1 if !other_pieces.contains(&(x, y + 2)) => HashSet::from([(x, 2), (x, 3)]),
     7 => HashSet::new(),
-    _ => HashSet::from([(x, y + 1)]),
+    _ => HashSet::from([(x, y + 1)])
 }
 ```
 

--- a/src/task_2/oppgave.md
+++ b/src/task_2/oppgave.md
@@ -20,6 +20,9 @@ med. Vi kommer til å fokusere på tre typer bondetrekk:
     - Generell bevegelse: Bonden kan bevege seg ett felt fremover
 - Angrepstrekk: Bonden kan slå brikker som befinner seg diagonalt foran bonden.
 
+> **Obs!:**  
+> Hvis en brikke står rett foran bonden, er både kort og lang åpning hindret.
+
 Bonden kan altså ikke gå til siden eller bakover, og den kan kun slå diagonalt. Se figuren under:
 
 ![Bondetrekk](../../images/moves/pawn.gif)

--- a/src/task_2/oppgave.md
+++ b/src/task_2/oppgave.md
@@ -1,11 +1,9 @@
 # Oppgave 2
-> **Mål:** Implementere vanlig bevegelse for _hvit bonde_
+> **Mål:** Ta hensyn til om andre brikker står i veien for _hvit bonde_
 
 > **Hvor skal jeg jobbe:** [piece/pawn.rs](piece/pawn.rs)
 
-I denne oppgaven fortsetter vi på forrige oppgave, og skal utvide `Pawn::get_moves()` til å gi oss åpningstrekk _og_
-vanlige trekk for hvite bonden. Vi bør også ta hensyn til at en annen brikke kan stå i veien for bondens steg 
-fremover. Du kan fortsatt se bort i fra:
+I denne oppgaven fortsetter vi på forrige oppgave, og skal utvide `get_forward_moves()` til å ta hensyn til at en annen brikke kan stå i veien for bondens steg fremover. Du kan fortsatt se bort i fra:
 - svarte bønder
 - trekk for å angripe
 
@@ -26,12 +24,11 @@ Bonden kan altså ikke gå til siden eller bakover, og den kan kun slå diagonal
 
 ![Bondetrekk](../../images/moves/pawn.gif)
 
-> **Merk!** I denne oppgaven skal vi kun implementere vanlig bevegelse for den hvite bonden.
+> **Merk!** I denne oppgaven skal vi kun utvide forovertrekken til bonden til å ta hensyn til andre brikker i veien.
 
 ## Oppgavebeskrivelse
 
-Utvid `Pawn::get_forward_moves()` til å returnere gyldige trekk for bonden (se bort i fra angrepstrekk) uansett hvor bonden befinner seg, og også om det er brikker i veien. Du kan se bort i fra nederste rad (der den hvite bonden aldri befinner 
-seg).
+Utvid `Pawn::get_forward_moves()` til å returnere gyldige trekk for bonden (se bort i fra angrepstrekk) også dersom det står brikker i veien.
 
 Oppgaven er fullført når testene kjører grønt.
 

--- a/src/task_2/oppgave.md
+++ b/src/task_2/oppgave.md
@@ -31,7 +31,8 @@ Bonden kan altså ikke gå til siden eller bakover, og den kan kun slå diagonal
 
 ## Oppgavebeskrivelse
 
-Utvid `Pawn::get_forward_moves()` til å returnere gyldige trekk for bonden (se bort i fra angrepstrekk) også dersom det står brikker i veien.
+- `get_forward_moves` trenger å vite hvor alle brikkene på brettet står, for å finne ut om et felt er ledig for bondens bevegelse. Dette kan du sende inn som argument i `get_moves`. Husk å oppdatere signaturen til `get_forward_moves`!
+- Utvid `get_forward_moves()` til å returnere gyldige forovertrekk for bonden uansett hvor bonden befinner seg, og også om det er brikker i veien. Du kan se bort i fra nederste rad (der den hvite bonden aldri befinner seg).
 
 Oppgaven er fullført når testene kjører grønt.
 

--- a/src/task_2/piece/pawn.rs
+++ b/src/task_2/piece/pawn.rs
@@ -15,8 +15,8 @@ impl Pawn {
     /// Returnerer et HashSet med alle trekkene en bonde kan gjøre forover, avhengig av hvor
     /// brikken står på brettet.
     ///
-    /// I denne oppgaven (2) skal du finne forovertrekkene til en hvit bonde (både åpningstrekk og
-    /// vanlig bevegelse), og du må ta hensyn til at det kan stå andre brikker i veien.
+    /// I denne oppgaven (2) skal du finne trekkene en hvit bonde kan gjøre fremover, og du må ta
+    /// hensyn til at det kan stå andre brikker i veien.
     ///
     /// For øyeblikket tar ikke denne metoden flere argumenter enn &self, men den burde nok ta inn
     /// de andre brikkene på brettet slik at vi kan sjekke om de er i veien for bondens bevegelse.
@@ -27,7 +27,8 @@ impl Pawn {
                 let (x, y) = self.position;
                 match y {
                     1 => HashSet::from([(x, 2), (x, 3)]),
-                    _ => todo!("Finn vanlige forovertrekk for bonden")
+                    7 => HashSet::new(),
+                    _ => HashSet::from([(x, y + 1)])
                 }
             }
             Color::Black => HashSet::new() // Se bort fra den svarte bonden i denne oppgaven
@@ -41,8 +42,6 @@ impl Pawn {
         HashSet::new()
     }
 }
-
-
 
 impl Piece for Pawn {
     fn new(color: Color, position: (u8, u8)) -> Self {

--- a/src/task_2/piece/pawn.rs
+++ b/src/task_2/piece/pawn.rs
@@ -21,10 +21,11 @@ impl Pawn {
     /// For øyeblikket tar ikke denne metoden flere argumenter enn &self, men den burde nok ta inn
     /// de andre brikkene på brettet slik at vi kan sjekke om de er i veien for bondens bevegelse.
     fn get_forward_moves(&self) -> HashSet<(u8, u8)> {
-        // todo!("Sjekk om det står brikker i veien for bonden")
+        // todo!("Ta inn posisjonene til andre brikker som argument")
         match self.color {
             Color::White => {
                 let (x, y) = self.position;
+                // todo!("Sjekk om det står brikker i veien for bonden")
                 match y {
                     1 => HashSet::from([(x, 2), (x, 3)]),
                     7 => HashSet::new(),
@@ -79,8 +80,7 @@ impl Piece for Pawn {
         team: &HashSet<(u8, u8)>,
         rival_team: &HashSet<(u8, u8)>,
     ) -> HashSet<(u8, u8)> {
-        // Her må vi nok gi et argument til self.get_forward_moves() for å kunne sjekke om det står
-        // en brikke i veien for bondens trekk
+        // todo!("Send inn et argument til self.get_forward_moves() for å kunne sjekke hvor andre brikker står")
         let forward_moves = self.get_forward_moves();
         let capture_moves = self.get_capture_moves();
 

--- a/src/task_3/oppgave.md
+++ b/src/task_3/oppgave.md
@@ -7,8 +7,8 @@ Denne oppgaven er en fortsettelse på forrige oppgave, nå skal vi implementere 
 Du må nå ta hensyn til hvor bonden står og hvor andre brikker står, men du trenger ikke å finne gyldige trekk for 
 den sorte bonden.
 
-Du må utvide `get_capture_moves()`-metoden til å støtte dette. I koden finner du også kommentarer som beskriver hva ulike 
-metoder gjør, og det står `todo!()` i metoden du skal implementere.
+- `get_capture_moves` trenger å vite hvor motstanderens brikker er. Utvid `get_moves` til å sende inn argument til `get_capture_moves` med fiendens posisjoner
+- Utvid `get_capture_moves()`-metoden til å returnere trekk hvor bonden kan slå fiendtlige brikker, _dersom_ det står en brikke av motsatt farge der.
 
 Du finner også hint i [hint.md](./hint.md).
 

--- a/src/task_3/piece/pawn.rs
+++ b/src/task_3/piece/pawn.rs
@@ -85,8 +85,7 @@ impl Piece for Pawn {
 
         let forward_moves = self.get_forward_moves(&other_pieces);
 
-        // Her må vi nok sende rival_team som argument, slik at vi kan sjekke om bonden har
-        // muligheten til å slå fiendtlige brikker
+        // todo!("Send inn rival_team som argument til self.get_capture_moves, for å vite om bonden kan slå fiendtlige brikker")
         let capture_moves = self.get_capture_moves();
 
         forward_moves.union(&capture_moves).cloned().collect()


### PR DESCRIPTION
Spiller videre på oppdelingen av forovertrekk (`get_forward_moves`) og angrepstrekk (`get_attack_moves`). Oppgave 1 nå omfatter både åpningstrekk og vanlig trekk forover for bonden, mens oppgave 2 nå handler om å ta hensyn til andre brikker som kan være i veien.