### PR TITLE
Skiller forover- og angrepstrekk for bonde, lettversjon

### DIFF
--- a/src/task_1/oppgave.md
+++ b/src/task_1/oppgave.md
@@ -16,8 +16,9 @@ Du finner også hint i [hint.md](./hint.md).
 ## Bondens trekk
 Bonden er den mest grunnleggende brikken i sjakk, men dens bevegelsesmønster kan være litt forvirrende til å begynne 
 med. Vi kommer til å fokusere på tre typer bondetrekk:
-- Åpningstrekk: Bonden kan bevege seg ett eller to felt fremover
-- Generell bevegelse: Bonden kan bevege seg ett felt fremover
+- Forovertrekk, som omfatter:
+  - Åpningstrekk: Bonden kan bevege seg ett eller to felt fremover
+  - Generell bevegelse: Bonden kan bevege seg ett felt fremover
 - Angrepstrekk: Bonden kan slå brikker som befinner seg diagonalt foran bonden.
 
 Bonden kan altså ikke gå til siden eller bakover, og den kan kun slå diagonalt. Se figuren under:
@@ -35,7 +36,7 @@ altså ikke tenke på:
 - angrepstrekk,
 - eller om andre brikker kan stå i veien (dette tar vi senere)
 
-Du løser oppgaven ved å implementere metodene som står definert inni `impl Piece for Pawn {}`-blokken. (Se etter
+Du løser oppgaven ved å implementere metodene som står definert inni `impl Piece`- og `impl Piece for Pawn {}`-blokkene. (Se etter
 `todo!()`) `Piece` er et slags *interface*, som kalles `trait` i Rust.
 
 Vi skal lage to nyttemetoder, for å ha tilgang til private felt:
@@ -49,7 +50,7 @@ Vi skal lage to nyttemetoder, for å ha tilgang til private felt:
 
 Vi skal også implementere to metoder vi trenger for å flytte bonden:
    - `move_piece` (endrer brikkens posisjon, foreløpig kun åpningstrekk og vanlig bevegelse fremover)
-   - `get_moves` (henter ut gyldige felt en brikke kan flytte til)
+   - `get_forward_moves` (gir oss gyldige forovertrekk for bonden)
 
 ## Eksempel
 Som vist i figuren over: Hvit bonde på `d2` skal kunne gå til `d3` og `d4` i åpningstrekket:

--- a/src/task_1/piece/pawn.rs
+++ b/src/task_1/piece/pawn.rs
@@ -10,6 +10,24 @@ pub struct Pawn {
     position: (u8, u8),
 }
 
+impl Pawn {
+    /// Returnerer et HashSet med alle trekkene en bonde kan gjøre forover, avhengig av hvor
+    /// brikken står på brettet.
+    ///
+    /// I denne oppgaven (1) trenger du kun å finne åpningstrekkene for hvit bonde, og du kan anta
+    /// at det ikke står andre brikker i veien
+    fn get_forward_moves(&self) -> HashSet<(u8, u8)> {
+        todo!("Returner et HashSet med gyldige åpningstrekk for bonden")
+    }
+
+    /// Returnerer trekken bonden kan gjøre for å angripe på skrå forover. Vi skal se på denne i 
+    /// oppgave 3.
+    fn get_capture_moves(&self) -> HashSet<(u8, u8)> {
+        // Denne skal vi se på i oppgave 3
+        HashSet::new()
+    }
+}
+
 impl Piece for Pawn {
     fn new(color: Color, position: (u8, u8)) -> Self {
         Pawn {
@@ -46,12 +64,10 @@ impl Piece for Pawn {
     /// Du trenger ikke å tenke på argumentene til denne oppgaven
     ///
     fn get_moves(&self, _: &HashSet<(u8, u8)>, _: &HashSet<(u8, u8)>) -> HashSet<(u8, u8)> {
-        match self.color {
-            Color::White => {
-                todo!()
-            }
-            Color::Black => HashSet::new() // Se bort fra den svarte bonden i denne oppgaven
-        }
+        let forward_moves = self.get_forward_moves();
+        let capture_moves = self.get_capture_moves();
+
+        forward_moves.union(&capture_moves).cloned().collect()
     }
 }
 

--- a/src/task_2/hint.md
+++ b/src/task_2/hint.md
@@ -62,6 +62,7 @@ let other_pieces: HashSet<_> = team.union(rival_team).collect();
 match y {
     _ if other_pieces.contains(&(x, y + 1)) => HashSet::new(),
     1 if !other_pieces.contains(&(x, y + 2)) => HashSet::from_iter([(x, 2), (x, 3)]),
+    7 => HashSet::new(),
     _ => HashSet::from_iter([(x, y + 1)]),
 }
 ```

--- a/src/task_2/oppgave.md
+++ b/src/task_2/oppgave.md
@@ -15,10 +15,11 @@ vil det finnes kommentarer som beskriver hva ulike metoder gjør, og det står `
 Du finner også hint i [hint.md](./hint.md).
 
 ## Bondens trekk
-Bonden er den mest grunnleggende brikken i sjakk, men dens bevegelsesmønster kan være litt forvirrende til å begynne 
+Bonden er den mest grunnleggende brikken i sjakk, men dens bevegelsesmønster kan være litt forvirrende til å begynne
 med. Vi kommer til å fokusere på tre typer bondetrekk:
-- Åpningstrekk: Bonden kan bevege seg ett eller to felt fremover
-- Generell bevegelse: Bonden kan bevege seg ett felt fremover
+- Forovertrekk, som omfatter:
+    - Åpningstrekk: Bonden kan bevege seg ett eller to felt fremover
+    - Generell bevegelse: Bonden kan bevege seg ett felt fremover
 - Angrepstrekk: Bonden kan slå brikker som befinner seg diagonalt foran bonden.
 
 Bonden kan altså ikke gå til siden eller bakover, og den kan kun slå diagonalt. Se figuren under:
@@ -29,8 +30,7 @@ Bonden kan altså ikke gå til siden eller bakover, og den kan kun slå diagonal
 
 ## Oppgavebeskrivelse
 
-Utvid `Pawn::get_moves()` til å returnere gyldige trekk for bonden (se bort i fra angrepstrekk) uansett hvor bonden 
-befinner seg, og også om det er brikker i veien. Du kan se bort i fra nederste rad (der den hvite bonden aldri befinner 
+Utvid `Pawn::get_forward_moves()` til å returnere gyldige trekk for bonden (se bort i fra angrepstrekk) uansett hvor bonden befinner seg, og også om det er brikker i veien. Du kan se bort i fra nederste rad (der den hvite bonden aldri befinner 
 seg).
 
 Oppgaven er fullført når testene kjører grønt.

--- a/src/task_2/piece/pawn.rs
+++ b/src/task_2/piece/pawn.rs
@@ -11,6 +11,39 @@ pub struct Pawn {
     position: (u8, u8),
 }
 
+impl Pawn {
+    /// Returnerer et HashSet med alle trekkene en bonde kan gjøre forover, avhengig av hvor
+    /// brikken står på brettet.
+    ///
+    /// I denne oppgaven (2) skal du finne forovertrekkene til en hvit bonde (både åpningstrekk og
+    /// vanlig bevegelse), og du må ta hensyn til at det kan stå andre brikker i veien.
+    ///
+    /// For øyeblikket tar ikke denne metoden flere argumenter enn &self, men den burde nok ta inn
+    /// de andre brikkene på brettet slik at vi kan sjekke om de er i veien for bondens bevegelse.
+    fn get_forward_moves(&self) -> HashSet<(u8, u8)> {
+        // todo!("Sjekk om det står brikker i veien for bonden")
+        match self.color {
+            Color::White => {
+                let (x, y) = self.position;
+                match y {
+                    1 => HashSet::from_iter([(x, 2), (x, 3)]),
+                    _ => todo!("Finn vanlige forovertrekk for bonden")
+                }
+            }
+            Color::Black => HashSet::new() // Se bort fra den svarte bonden i denne oppgaven
+        }
+    }
+
+    /// Returnerer trekken bonden kan gjøre for å angripe på skrå forover. Vi skal se på denne i
+    /// oppgave 3.
+    fn get_capture_moves(&self) -> HashSet<(u8, u8)> {
+        // Denne skal vi se på i oppgave 3
+        HashSet::new()
+    }
+}
+
+
+
 impl Piece for Pawn {
     fn new(color: Color, position: (u8, u8)) -> Self {
         Pawn { color, position }
@@ -42,22 +75,17 @@ impl Piece for Pawn {
     /// # Argumenter
     /// - `team` Referanse til et HashSet som inneholder dine brikkers posisjoner.
     /// - `rival_team` Referanse til et HashSet som inneholder posisjonene til motstanderens brikker.
-    ///
     fn get_moves(
         &self,
         team: &HashSet<(u8, u8)>,
         rival_team: &HashSet<(u8, u8)>,
     ) -> HashSet<(u8, u8)> {
-        match self.color {
-            Color::White => {
-                let (x, y) = self.position;
-                match y {
-                    1 => HashSet::from_iter([(x, 2), (x, 3)]),
-                    _ => todo!(),
-                }
-            }
-            Color::Black => HashSet::new(), // Se bort fra den svarte bonden i denne oppgaven
-        }
+        // Her må vi nok gi et argument til self.get_forward_moves() for å kunne sjekke om det står
+        // en brikke i veien for bondens trekk
+        let forward_moves = self.get_forward_moves();
+        let capture_moves = self.get_capture_moves();
+
+        forward_moves.union(&capture_moves).cloned().collect()
     }
 }
 

--- a/src/task_3/hint.md
+++ b/src/task_3/hint.md
@@ -33,9 +33,9 @@ Ta gjerne en ekstra titt i `src/square.rs` i fall du kan finne noe som bli nytti
 ## Hint som avslører en mulig løsning
 
 <details>
-<summary>Hint 3 – Algoritme for å finne bondetrekk</summary>
+<summary>Hint 3 – Algoritme for å finne angrepstrekk for bonden</summary>
 
-Én mulig fremgangsmåte for å beregne bondetrekk er å undersøke hvor bonden befinner seg for øyeblikket, og så inkludere
+Én mulig fremgangsmåte for å beregne bondens angrepstrekk er å undersøke hvor bonden befinner seg for øyeblikket, og så inkludere
 felter avhengig av dette. En alternativ fremgangsmåte er å inkludere felter litt mer ukritisk, og deretter filtrere bort
 det som ikke er gyldige posisjoner.
 

--- a/src/task_3/oppgave.md
+++ b/src/task_3/oppgave.md
@@ -7,7 +7,7 @@ Denne oppgaven er en fortsettelse på forrige oppgave, nå skal vi implementere 
 Du må nå ta hensyn til hvor bonden står og hvor andre brikker står, men du trenger ikke å finne gyldige trekk for 
 den sorte bonden.
 
-Du må utvide `get_moves()` metoden til å støtte dette. I koden finner du også kommentarer som beskriver hva ulike 
+Du må utvide `get_capture_moves()`-metoden til å støtte dette. I koden finner du også kommentarer som beskriver hva ulike 
 metoder gjør, og det står `todo!()` i metoden du skal implementere.
 
 Du finner også hint i [hint.md](./hint.md).

--- a/src/task_3/piece/pawn.rs
+++ b/src/task_3/piece/pawn.rs
@@ -12,6 +12,37 @@ pub struct Pawn {
     position: (u8, u8),
 }
 
+impl Pawn {
+    /// Returnerer et HashSet med alle trekkene en bonde kan gjøre forover, avhengig av hvor
+    /// brikken står på brettet.
+    fn get_forward_moves(&self, other_pieces: &HashSet<(u8, u8)>) -> HashSet<(u8, u8)> {
+        match self.color {
+            Color::White => {
+                let (x, y) = self.position;
+                match y {
+                    _ if other_pieces.contains(&(x, y + 1)) => HashSet::new(),
+                    1 if !other_pieces.contains(&(x, y + 2)) => HashSet::from_iter([(x, 2), (x, 3)]),
+                    7 => HashSet::new(),
+                    _ => HashSet::from([(x, y + 1)])
+                }
+            }
+            Color::Black => HashSet::new() // Se bort fra den svarte bonden i denne oppgaven
+        }
+    }
+
+    /// Returnerer trekken bonden kan gjøre for å angripe på skrå forover.
+    ///
+    /// I denne oppgaven (3) skal du finne trekk der hvit bonde kan angripe en brikke på skrå
+    /// forover. Du må derfor ta hensyn til hvor motstanderens brikker står.
+    ///
+    /// For øyeblikket tar ikke denne metoden flere argumenter enn &self, men den burde nok ta inn
+    /// motstanderens brikker slik at vi kan sjekke om de står for slag.
+    fn get_capture_moves(&self) -> HashSet<(u8, u8)> {
+        // todo!("Returner trekk der bonden kan slå en annen brikke")
+        HashSet::new()
+    }
+}
+
 impl Piece for Pawn {
     fn new(color: Color, position: (u8, u8)) -> Self {
         Pawn { color, position }
@@ -50,24 +81,15 @@ impl Piece for Pawn {
         team: &HashSet<(u8, u8)>,
         rival_team: &HashSet<(u8, u8)>,
     ) -> HashSet<(u8, u8)> {
-        match self.color {
-            Color::White => {
-                // Du kan gjerne bruke din egen implementasjon fra forrige oppgave her
-                let (x, y) = self.position;
-                let other_pieces: HashSet<_> = team.union(rival_team).collect();
+        let other_pieces: HashSet<_> = team.union(rival_team).cloned().collect();
 
-                let forward_moves = match y {
-                    _ if other_pieces.contains(&(x, y + 1)) => HashSet::new(),
-                    1 if !other_pieces.contains(&(x, y + 2)) => {
-                        HashSet::from_iter([(x, 2), (x, 3)])
-                    }
-                    _ => HashSet::from_iter([(x, y + 1)]),
-                };
-                let capture_moves = HashSet::new(); // Denne skal inneholde angrepstrekk
-                forward_moves.union(&capture_moves).cloned().collect()
-            }
-            Color::Black => HashSet::new(), // Denne løser vi i neste oppgave
-        }
+        let forward_moves = self.get_forward_moves(&other_pieces);
+
+        // Her må vi nok sende rival_team som argument, slik at vi kan sjekke om bonden har
+        // muligheten til å slå fiendtlige brikker
+        let capture_moves = self.get_capture_moves();
+
+        forward_moves.union(&capture_moves).cloned().collect()
     }
 }
 

--- a/src/task_4/hint.md
+++ b/src/task_4/hint.md
@@ -15,62 +15,10 @@ Spesielt dobbel `match` er fin å bruke dersom du både vil sjekke på brikkens 
 
 </details>
 
-<details>
-<summary>Hint 2 – Samle det som er felles</summary>
-
-I `get_moves()` kan det være lurt å starte med å dra ut det som er felles for både hvit og svart bonde:
-
-```rust
-fn get_moves(&self, team: &HashSet<(u8, u8)>, rival_team: &HashSet<(u8, u8)>) -> HashSet<(u8, u8)> {
-    let (x, y) = self.position;
-    let forward_moves = match (self.color, y) {
-        // Fyll inn kode for å finne vanlige trekk
-    };
-    let (x, y) = self.position.as_u8().unwrap();
-    let capture_moves = match (self.color, y) {
-        // Fyll inn kode for å finne angrepstrekk
-    };
-    forward_moves.union(&capture_moves).cloned().collect()
-}
-```
-
-</details>
-
-<details>
-<summary>Hint 3 – Skille ut metoder</summary>
-
-Blir det høy kompleksitet i `Pawn::get_moves()`? Du kan alltids lage nye metoder og kalle på disse fra `get_moves()`.
-Merk at disse må legges i en `impl Pawn`-blokk (ikke `impl Piece for Pawn`) ettersom dette i så fall er metoder som 
-ikke tilhører `Piece`-traiten.
-
-Her er et eksempel:
-```rust
-impl Piece {
-  fn get_forward_moves(all_pieces: &HashSet<(u8, u8)>) -> HashSet<(u8, u8)> {
-    todo!()
-  }
-  fn get_capture_moves(rival_team: &HashSet<(u8, u8)>) -> HashSet<(u8, u8)> {
-    todo!()
-  }
-}
-
-impl Piece for Pawn {
-  ...
-  fn get_moves(&self, team: &HashSet<(u8, u8)>, rival_team: &HashSet<(u8, u8)>) -> HashSet<(u8, u8)> {
-    let all_pieces = team.union(&rival_team).cloned().collect();
-    let forward_moves = self.get_forward_moves(&all_pieces);
-    let capture_moves = self.get_capture_moves(rival_team);
-    forward_moves.union(&capture_moves).cloned().collect()
-  }
-}
-```
-
-</details>
-
 ## Hint som avslører en mulig løsning
 
 <details>
-<summary>Hint 4 – Algoritme for å finne bondetrekk</summary>
+<summary>Hint 2 – Algoritme for å finne bondetrekk</summary>
 
 ```rust
 impl Pawn {

--- a/src/task_4/oppgave.md
+++ b/src/task_4/oppgave.md
@@ -5,16 +5,16 @@
 
 Denne oppgaven generaliserer vi trekkene for den hvite bonden slik vi også kan finne trekkene til den sorte bonden.
 
-Du må utvide `get_moves()` metoden til å støtte dette. Se etter en `todo!()`. I koden finner du også kommentarer som 
-beskriver hva ulike metoder gjør.
+Du må utvide `get_forward_moves()`- og `get_capture_moves`-metodene til å støtte dette. Se etter en `todo!()`. I koden finner du også kommentarer som beskriver hva ulike metoder gjør.
 
 Du finner også hint i [hint.md](./hint.md).
 
 ## Bondens trekk
 Bonden er den mest grunnleggende brikken i sjakk, men dens bevegelsesmønster kan være litt forvirrende til å begynne
 med. Vi kommer til å fokusere på tre typer bondetrekk:
-- Åpningstrekk: Bonden kan bevege seg ett eller to felt fremover
-- Generell bevegelse: Bonden kan bevege seg ett felt fremover
+- Forovertrekk, som omfatter:
+    - Åpningstrekk: Bonden kan bevege seg ett eller to felt fremover
+    - Generell bevegelse: Bonden kan bevege seg ett felt fremover
 - Angrepstrekk: Bonden kan slå brikker som befinner seg diagonalt foran bonden.
 
 Bonden kan altså ikke gå til siden eller bakover, og den kan kun slå diagonalt. Se figuren under:

--- a/src/task_4/piece/pawn.rs
+++ b/src/task_4/piece/pawn.rs
@@ -10,6 +10,40 @@ pub struct Pawn {
     position: (u8, u8),
 }
 
+impl Pawn {
+    /// Returnerer et HashSet med alle trekkene en bonde kan gjøre forover, avhengig av hvor
+    /// brikken står på brettet.
+    ///
+    /// I denne oppgaven (4) skal du også finne gyldige forovertrekk for svart bonde.
+    fn get_forward_moves(&self, other_pieces: &HashSet<(u8, u8)>) -> HashSet<(u8, u8)> {
+        match self.color {
+            Color::White => {
+                let (x, y) = self.position;
+                match y {
+                    _ if other_pieces.contains(&(x, y + 1)) => HashSet::new(),
+                    1 if !other_pieces.contains(&(x, y + 2)) => HashSet::from_iter([(x, 2), (x, 3)]),
+                    7 => HashSet::new(),
+                    _ => HashSet::from([(x, y + 1)])
+                }
+            }
+            Color::Black => {
+                todo!()
+            }
+        }
+    }
+
+    /// Returnerer trekken bonden kan gjøre for å angripe på skrå forover.
+    ///
+    /// I denne oppgaven (4) skal du også finne gyldige angrepstrekk for svart bonde.
+    fn get_capture_moves(&self, rival_team: &HashSet<(u8, u8)>) -> HashSet<(u8, u8)> {
+        let (x, y) = self.position.as_i8().unwrap();
+        HashSet::from_iter([(x - 1, y + 1), (x + 1, y + 1)])
+            .as_board_positions()
+            .intersection(rival_team).cloned().collect()
+        // todo!("Returner gyldige angrepstrekk også for svart bonde")
+    }
+}
+
 impl Piece for Pawn {
     fn new(color: Color, position: (u8, u8)) -> Self {
         Pawn { color, position }
@@ -48,29 +82,11 @@ impl Piece for Pawn {
         team: &HashSet<(u8, u8)>,
         rival_team: &HashSet<(u8, u8)>,
     ) -> HashSet<(u8, u8)> {
-        match self.color {
-            Color::White => {
-                // Du kan gjerne bruke din egen implementasjon fra forrige oppgave her
-                let (x, y) = self.position;
-                let other_pieces: HashSet<_> = team.union(rival_team).collect();
+        let other_pieces: HashSet<_> = team.union(rival_team).cloned().collect();
+        let forward_moves = self.get_forward_moves(&other_pieces);
+        let capture_moves = self.get_capture_moves(rival_team);
 
-                let forward_moves = match y {
-                    _ if other_pieces.contains(&(x, y + 1)) => HashSet::new(),
-                    1 if !other_pieces.contains(&(x, y + 2)) => {
-                        HashSet::from_iter([(x, 2), (x, 3)])
-                    }
-                    _ => HashSet::from_iter([(x, y + 1)]),
-                };
-                let (x, y) = self.position.as_i8().unwrap();
-                let capture_moves = HashSet::from_iter([(x - 1, y + 1), (x + 1, y + 1)])
-                    .as_board_positions()
-                    .intersection(rival_team)
-                    .cloned()
-                    .collect();
-                forward_moves.union(&capture_moves).cloned().collect()
-            }
-            Color::Black => todo!(),
-        }
+        forward_moves.union(&capture_moves).cloned().collect()
     }
 }
 


### PR DESCRIPTION
Skiller mellom trekk forover (`get_forward_moves`) og angrepstrekk (`get_capture_moves`) for bonde allerede fra oppgave 1. Intensjonen er at dette skal gjøre det enklere for deltakere å avgrense hva de skal løse i oppgave 1, og etablere allerede fra starten av hvordan man slår sammen to `HashSet` gjennom `union`-metoden.

Denne oppsplittingen _beholder_ selve innholdet i bondeoppgavene:
1. Åpningstrekk for hvit bonde
2. Andre forovertrekk for hvit bonde, og må ta hensyn til andre brikker
3. Angrepstrekk for hvit bonde
4. Alle trekk for sort bonde